### PR TITLE
Add main/init placement and read configuration file from outside

### DIFF
--- a/.goreorder
+++ b/.goreorder
@@ -1,0 +1,11 @@
+# vim: ft=yaml
+format: gofmt
+write: true
+verbose: true
+reorder-types: true
+diff: false
+order:
+- const
+- var
+- init
+- main

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Available Commands:
   reorder      Reorder vars, consts, stucts/types/interaces, methods/functions and constructors in a Go source file.
 
 Flags:
-  -h, --help      Show help
-  -V, --version   Show version
+  -h, --help      help for goreorder
+  -v, --version   version for goreorder
 
 Use "goreorder [command] --help" for more information about a command.
 ```
@@ -77,7 +77,12 @@ Flags:
   -d, --diff            Make a diff instead of rewriting the file
   -f, --format string   Format tool to use (gofmt or goimports) (default "gofmt")
   -h, --help            help for reorder
-  -o, --order strings   Order of the elements. Omitting elements is allowed, the needed elements will be appended
+  -o, --order strings   Order of the elements. You can omit some elements, they will be added at the end.
+                        There are 2 special values that are not part of the default order: "init" and "main". If
+                        you specify "init" or "main" in the order, they will be added placed where you put them
+                        and so they will not be included in "func". This to allow to have the init() function
+                        and the main() function at the top of the file. Or whatever you want.
+                        Allowed values are: main, init, const, var, interface, type, func
   -r, --reorder-types   Reordering types in addition to methods
   -v, --verbose         Verbose output
   -w, --write           Write result to (source) file instead of stdout
@@ -86,6 +91,30 @@ Flags:
 You can create a `.goreorder` file containing configuration at the root of your project. Use the `goreorder print-config` command (you can redirect the output to the `.goreorder` file).
 
 > Warning, `print-config` shows the current configuration. If the file doesn't exist, so the default values are displayed. If it exists, so the current values are displayed. To reset the file, remove it and rerun the `print-config` subcommand.
+
+# Specific cases for `main()` and `init()` functions
+
+By default, `main()` and `init()` functions are part of the functions. So they are sorted with the others functions. If you don't want this behavior, you can specify where to place them using the `--order` argument or using the `.goreorder` configuration file.
+
+For example, in command line:
+```bash
+goreorder reorder --order const,var,init,main ./
+```
+
+Or in configuration:
+
+```yaml
+format: gofmt
+write: true
+verbose: true
+reorder-types: true
+diff: false
+order:
+- const
+- var
+- init
+- main
+```
 
 # Avoid destruction with `--diff`
 

--- a/cmd/goreorder/commands.go
+++ b/cmd/goreorder/commands.go
@@ -110,10 +110,12 @@ func buildReorderCommand(config *ReorderConfig) *cobra.Command {
 			}
 
 			// validate order flags
+			validOrder := config.DefOrder
+			validOrder = append(validOrder, []string{"main", "init"}...)
 			if len(config.DefOrder) > 0 {
 				for _, v := range config.DefOrder {
 					found := false
-					for _, w := range ordering.DefaultOrder {
+					for _, w := range validOrder {
 						if v == w {
 							found = true
 							break

--- a/cmd/goreorder/commands.go
+++ b/cmd/goreorder/commands.go
@@ -162,7 +162,12 @@ func buildReorderCommand(config *ReorderConfig) *cobra.Command {
 	reoderCommand.Flags().StringSliceVarP(
 		&config.DefOrder,
 		"order", "o", config.DefOrder,
-		"Order of the elements. Omitting elements is allowed, the needed elements will be appended")
+		`Order of the elements. You can omit some elements, they will be added at the end.
+There are 2 special values that are not part of the default order: "init" and "main". If
+you specify "init" or "main" in the order, they will be added placed where you put them
+and so they will not be included in "func". This to allow to have the init() function
+and the main() function at the top of the file. Or whatever you want.
+Allowed values are: main, init, `+strings.Join(ordering.DefaultOrder, ", "))
 	return reoderCommand
 
 }

--- a/cmd/goreorder/commands.go
+++ b/cmd/goreorder/commands.go
@@ -64,7 +64,7 @@ func buildMainCommand() *cobra.Command {
 		Long:    fmt.Sprintf(usage, filepath.Base(os.Args[0])),
 		Version: version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initializeViper(cmd)
+			return initializeViper(cmd, args...)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("You need to specify a command or an option")

--- a/cmd/goreorder/config.go
+++ b/cmd/goreorder/config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -10,12 +12,24 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func initializeViper(c *cobra.Command) error {
+func initializeViper(c *cobra.Command, args ...string) error {
 	v := viper.New()
 	v.SetConfigName(".goreorder")
 	v.SetConfigType("yaml")
 
 	v.AddConfigPath(".")
+	// also, add the projet root
+	for _, arg := range args {
+		stat, err := os.Stat(arg)
+		if err != nil {
+			continue
+		}
+		if stat.IsDir() {
+			v.AddConfigPath(arg)
+		} else {
+			v.AddConfigPath(filepath.Dir(arg))
+		}
+	}
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/cmd/goreorder/main.go
+++ b/cmd/goreorder/main.go
@@ -36,6 +36,13 @@ var (
 	defaultOutpout io.Writer = os.Stdout
 )
 
+func main() {
+	if err := buildMainCommand().Execute(); err != nil {
+		fmt.Println(fmt.Errorf("%v", err))
+		os.Exit(1)
+	}
+}
+
 type ReorderConfig struct {
 	FormatToolName string   `yaml:"format"`
 	Write          bool     `yaml:"write"`
@@ -43,13 +50,6 @@ type ReorderConfig struct {
 	ReorderTypes   bool     `yaml:"reorder-types"`
 	MakeDiff       bool     `yaml:"diff"`
 	DefOrder       []string `yaml:"order"`
-}
-
-func main() {
-	if err := buildMainCommand().Execute(); err != nil {
-		fmt.Println(fmt.Errorf("%v", err))
-		os.Exit(1)
-	}
 }
 
 func processFile(fileOrDirectoryName string, input []byte, config *ReorderConfig) {

--- a/log/main.go
+++ b/log/main.go
@@ -12,6 +12,11 @@ var (
 	logger *l.Logger
 )
 
+func init() {
+	// set the log output to stderr
+	logger = l.New(os.Stderr, "", l.LstdFlags)
+}
+
 func GetLogger() *l.Logger {
 	return logger
 }
@@ -25,9 +30,4 @@ func SetVerbose(v bool) {
 		writer, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0666)
 		logger.SetOutput(writer)
 	}
-}
-
-func init() {
-	// set the log output to stderr
-	logger = l.New(os.Stderr, "", l.LstdFlags)
 }

--- a/ordering/main.go
+++ b/ordering/main.go
@@ -90,19 +90,16 @@ func processConst(
 	return source
 }
 
-func processFunctions(
+func processExtractedFunction(
 	info *ParsedInfo,
 	functionNames, originalContent, source []string,
 	removedLines, lineNumberWhereInject *int,
 	sign string,
-	extactinit, extactmain bool,
+	funcname string,
 ) []string {
 	for _, name := range functionNames {
 
-		if name == "init" && extactinit {
-			continue
-		}
-		if name == "main" && extactmain {
+		if funcname != name {
 			continue
 		}
 
@@ -119,16 +116,19 @@ func processFunctions(
 	return source
 }
 
-func processExtractedFunction(
+func processFunctions(
 	info *ParsedInfo,
 	functionNames, originalContent, source []string,
 	removedLines, lineNumberWhereInject *int,
 	sign string,
-	funcname string,
+	extactinit, extactmain bool,
 ) []string {
 	for _, name := range functionNames {
 
-		if funcname != name {
+		if name == "init" && extactinit {
+			continue
+		}
+		if name == "main" && extactmain {
 			continue
 		}
 

--- a/ordering/main.go
+++ b/ordering/main.go
@@ -14,15 +14,24 @@ import (
 
 const (
 	Const     Order = "const"
+	Init      Order = "init"
+	Main      Order = "main"
 	Var       Order = "var"
 	Interface Order = "interface"
 	Type      Order = "type"
 	Func      Order = "func"
 )
 
+// DefaultOrder is the default order of elements.
+//
+// Note, Init and Main are not in the list. If they are present, the init and main functions
+// will be moved.
 var DefaultOrder = []Order{Const, Var, Interface, Type, Func}
 
+// Order is the type of order, it's an alias of string.
 type Order = string
+
+// ReorderConfig is the configuration for the reorder function.
 type ReorderConfig struct {
 	Filename       string
 	FormatCommand  string
@@ -86,8 +95,43 @@ func processFunctions(
 	functionNames, originalContent, source []string,
 	removedLines, lineNumberWhereInject *int,
 	sign string,
+	extactinit, extactmain bool,
 ) []string {
 	for _, name := range functionNames {
+
+		if name == "init" && extactinit {
+			continue
+		}
+		if name == "main" && extactmain {
+			continue
+		}
+
+		sourceCode := info.Functions[name]
+		if *removedLines == 0 {
+			*lineNumberWhereInject = info.Functions[name].OpeningLine
+		}
+		for ln := sourceCode.OpeningLine - 1; ln < sourceCode.ClosingLine; ln++ {
+			originalContent[ln] = "// -- " + sign
+		}
+		source = append(source, "\n"+sourceCode.SourceCode)
+		*removedLines += len(info.Functions)
+	}
+	return source
+}
+
+func processExtractedFunction(
+	info *ParsedInfo,
+	functionNames, originalContent, source []string,
+	removedLines, lineNumberWhereInject *int,
+	sign string,
+	funcname string,
+) []string {
+	for _, name := range functionNames {
+
+		if funcname != name {
+			continue
+		}
+
 		sourceCode := info.Functions[name]
 		if *removedLines == 0 {
 			*lineNumberWhereInject = info.Functions[name].OpeningLine
@@ -285,6 +329,17 @@ func ReorderSource(opt ReorderConfig) (string, error) {
 	lineNumberWhereInject := 0
 	removedLines := 0
 
+	extactinit := false
+	extractmain := false
+	for _, order := range opt.DefOrder {
+		if order == Init {
+			extactinit = true
+		}
+		if order == Main {
+			extractmain = true
+		}
+	}
+
 	for _, order := range opt.DefOrder {
 		switch order {
 		case Const:
@@ -306,7 +361,6 @@ func ReorderSource(opt ReorderConfig) (string, error) {
 				&removedLines, &lineNumberWhereInject,
 				sign,
 			)
-
 		case Type:
 			source = processTypes(
 				info,
@@ -320,6 +374,23 @@ func ReorderSource(opt ReorderConfig) (string, error) {
 				functionNames, originalContent, source,
 				&removedLines, &lineNumberWhereInject,
 				sign,
+				extactinit, extractmain,
+			)
+		case Init:
+			source = processExtractedFunction(
+				info,
+				functionNames, originalContent, source,
+				&removedLines, &lineNumberWhereInject,
+				sign,
+				"init",
+			)
+		case Main:
+			source = processExtractedFunction(
+				info,
+				functionNames, originalContent, source,
+				&removedLines, &lineNumberWhereInject,
+				sign,
+				"main",
 			)
 		}
 	}

--- a/repo-tools/install.sh
+++ b/repo-tools/install.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#!/bin/sh
 
 # config
 GIT_REPOSITORY=https://github.com/metal3d


### PR DESCRIPTION
Some enhancements:

- Allow to place `main` and `init` functions
- Read configuration file from the root of the project (if the command is launched outside the project)